### PR TITLE
Fixed RuleBookRunner.getResult() always returns a value

### DIFF
--- a/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/runner/AbstractRuleBookRunner.java
+++ b/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/runner/AbstractRuleBookRunner.java
@@ -53,7 +53,7 @@ public abstract class AbstractRuleBookRunner extends Auditor implements RuleBook
       for (Class<?> rule : classes) {
         try {
           getAnnotatedField(com.deliveredtechnologies.rulebook.annotation.Result.class, rule).ifPresent(field ->
-              ruleBook.setDefaultResult(_result.getValue() == null ? new Object() : _result.getValue())
+              ruleBook.setDefaultResult(_result.getValue())
           );
           String name = getAnnotation(com.deliveredtechnologies.rulebook.annotation.Rule.class, rule).name();
           if (name.equals("None")) {

--- a/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/runner/RuleAdapter.java
+++ b/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/runner/RuleAdapter.java
@@ -189,8 +189,9 @@ public class RuleAdapter implements Rule {
           .ifPresent(field -> {
             field.setAccessible(true);
             try {
-              if (result.getValue().getClass() != Object.class
-                  || field.getType().isAssignableFrom(result.getValue().getClass())) {
+              if (result.getValue() != null
+                  && (result.getValue().getClass() != Object.class
+                  || field.getType().isAssignableFrom(result.getValue().getClass()))) {
                 field.set(_pojoRule, result.getValue());
               }
             } catch (Exception ex) {


### PR DESCRIPTION
Don't setDefaultResult(...) to a new Object if result is null
Add a check for null in RuleAdapter.setResult()