### PR TITLE
Feature/issue127 rule exception handling

### DIFF
--- a/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/GoldenRule.java
+++ b/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/GoldenRule.java
@@ -184,7 +184,9 @@ public class GoldenRule<T, U> implements Rule<T, U> {
                       } catch (IllegalAccessException | InvocationTargetException err) {
                         LOGGER.error("Error invoking action on " + action.getClass(), err);
                         if (_actionType.equals(ERROR_ON_FAILURE)) {
-                          throw new RuleException(err);
+                          throw err.getCause() == null ? new RuleException(err) :
+                              err.getCause() instanceof RuleException ? (RuleException)err.getCause() :
+                                  new RuleException(err.getCause());
                         }
                       }
                     });

--- a/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/GoldenRule.java
+++ b/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/GoldenRule.java
@@ -201,7 +201,7 @@ public class GoldenRule<T, U> implements Rule<T, U> {
       //catch errors from the 'when' condition; if it fails, just continue along unless ERROR_ON_FAILURE is set
       LOGGER.error("Error occurred when trying to evaluate rule!", ex);
       if (_actionType.equals(ERROR_ON_FAILURE)) {
-        throw new RuleException(ex);
+        throw ex instanceof RuleException ? (RuleException)ex : new RuleException(ex);
       }
     }
 

--- a/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/runner/RuleAdapter.java
+++ b/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/runner/RuleAdapter.java
@@ -148,7 +148,7 @@ public class RuleAdapter implements Rule {
                 return (Boolean) method.invoke(_pojoRule);
               } catch (InvocationTargetException | IllegalAccessException ex) {
                 if (_actionType == RuleChainActionType.ERROR_ON_FAILURE) {
-                  throw new RuleException(ex);
+                  throw new RuleException(ex.getCause() == null ? ex : ex.getCause());
                 }
                 LOGGER.error(
                     "Unable to validate condition due to an exception. It will be evaluated as false", ex);

--- a/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/runner/RuleAdapter.java
+++ b/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/runner/RuleAdapter.java
@@ -289,9 +289,12 @@ public class RuleAdapter implements Rule {
                 Object resultVal = resultField.get(_pojoRule);
                 ((com.deliveredtechnologies.rulebook.Result) result).setValue(resultVal);
               } catch (IllegalAccessException | InvocationTargetException ex) {
-                LOGGER.error("Unable to access "
-                      + _pojoRule.getClass().getName()
-                      + " when converting then to BiConsumer", ex);
+                if (_actionType == RuleChainActionType.ERROR_ON_FAILURE) {
+                  throw new RuleException(ex.getCause() == null ? ex : ex.getCause());
+                }
+                LOGGER.error("Unable to invoke "
+                    + _pojoRule.getClass().getName()
+                    + " when converting then to BiConsumer", ex);
               }
             });
   }
@@ -306,9 +309,12 @@ public class RuleAdapter implements Rule {
             _rule.setRuleState(RuleState.BREAK);
           }
         } catch (IllegalAccessException | InvocationTargetException ex) {
-          LOGGER.error("Unable to access "
-                + _pojoRule.getClass().getName()
-                + " when converting then to Consumer", ex);
+          if (_actionType == RuleChainActionType.ERROR_ON_FAILURE) {
+            throw new RuleException(ex.getCause() == null ? ex : ex.getCause());
+          }
+          LOGGER.error("Unable to invoke "
+                  + _pojoRule.getClass().getName()
+                  + " when converting then to Consumer", ex);
         }
       });
     }

--- a/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/runner/RuleBookRunnerTest.java
+++ b/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/runner/RuleBookRunnerTest.java
@@ -8,6 +8,7 @@ import com.deliveredtechnologies.rulebook.model.Rule;
 import com.deliveredtechnologies.rulebook.model.RuleStatus;
 import com.deliveredtechnologies.rulebook.model.Auditor;
 import com.deliveredtechnologies.rulebook.model.RuleException;
+import com.deliveredtechnologies.rulebook.model.runner.test.rulebooks.error.action.CustomException;
 import net.jodah.concurrentunit.Waiter;
 import org.junit.Assert;
 import org.junit.Test;
@@ -206,14 +207,32 @@ public class RuleBookRunnerTest {
   }
 
   @Test
-  public void errorOnFailureRulesThrowErrorsInRuleBookRunners() {
+  public void errorOnConditionFailureRulesThrowErrorsInRuleBookRunners() {
     RuleBookRunner ruleBook =
-        new RuleBookRunner("com.deliveredtechnologies.rulebook.model.runner.test.rulebooks.error");
+        new RuleBookRunner("com.deliveredtechnologies.rulebook.model.runner.test.rulebooks.error.condition");
 
     try {
       ruleBook.run(new FactMap());
     } catch (RuleException err) {
+      Assert.assertTrue(err.getCause() instanceof Exception);
+      Assert.assertEquals("Sumthin' Broke!", err.getCause().getMessage());
       Assert.assertEquals(ruleBook.getRuleStatus("SampleRule"), RuleStatus.EXECUTED);
+      Assert.assertEquals(ruleBook.getRuleStatus("ErrorRule"), RuleStatus.PENDING);
+      return;
+    }
+    Assert.fail();
+  }
+
+  @Test
+  public void errorOnActionFailureRulesThrowErrorsInRuleBookRunners() {
+    RuleBookRunner ruleBook =
+        new RuleBookRunner("com.deliveredtechnologies.rulebook.model.runner.test.rulebooks.error.action");
+
+    try {
+      ruleBook.run(new FactMap());
+    } catch (RuleException err) {
+      Assert.assertTrue(err.getCause() instanceof CustomException);
+      Assert.assertEquals("Sumthin' Broke!", err.getCause().getMessage());
       Assert.assertEquals(ruleBook.getRuleStatus("ErrorRule"), RuleStatus.PENDING);
       return;
     }

--- a/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/runner/test/rulebooks/error/action/CustomException.java
+++ b/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/runner/test/rulebooks/error/action/CustomException.java
@@ -1,0 +1,7 @@
+package com.deliveredtechnologies.rulebook.model.runner.test.rulebooks.error.action;
+
+public class CustomException extends Exception {
+  public CustomException(String message) {
+    super(message);
+  }
+}

--- a/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/runner/test/rulebooks/error/action/ErrorRule.java
+++ b/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/runner/test/rulebooks/error/action/ErrorRule.java
@@ -1,4 +1,4 @@
-package com.deliveredtechnologies.rulebook.model.runner.test.rulebooks.error;
+package com.deliveredtechnologies.rulebook.model.runner.test.rulebooks.error.action;
 
 import com.deliveredtechnologies.rulebook.annotation.Rule;
 import com.deliveredtechnologies.rulebook.annotation.Then;
@@ -9,13 +9,15 @@ import static com.deliveredtechnologies.rulebook.model.RuleChainActionType.ERROR
 /**
  * Created by clayton.long on 5/8/18.
  */
-@Rule(order = 2, ruleChainAction = ERROR_ON_FAILURE)
+@Rule(ruleChainAction = ERROR_ON_FAILURE)
 public class ErrorRule {
   @When
-  public boolean when() throws Exception {
-    throw new Exception("Sumthin' Broke!");
+  public boolean when() {
+    return true;
   }
 
   @Then
-  public void then() {}
+  public void then() throws Exception {
+    throw new Exception("Sumthin' Broke!");
+  }
 }

--- a/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/runner/test/rulebooks/error/action/ErrorRule.java
+++ b/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/runner/test/rulebooks/error/action/ErrorRule.java
@@ -18,6 +18,6 @@ public class ErrorRule {
 
   @Then
   public void then() throws Exception {
-    throw new Exception("Sumthin' Broke!");
+    throw new CustomException("Sumthin' Broke!");
   }
 }

--- a/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/runner/test/rulebooks/error/condition/ErrorRule.java
+++ b/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/runner/test/rulebooks/error/condition/ErrorRule.java
@@ -1,0 +1,21 @@
+package com.deliveredtechnologies.rulebook.model.runner.test.rulebooks.error.condition;
+
+import com.deliveredtechnologies.rulebook.annotation.Rule;
+import com.deliveredtechnologies.rulebook.annotation.Then;
+import com.deliveredtechnologies.rulebook.annotation.When;
+
+import static com.deliveredtechnologies.rulebook.model.RuleChainActionType.ERROR_ON_FAILURE;
+
+/**
+ * Created by clayton.long on 5/8/18.
+ */
+@Rule(order = 2, ruleChainAction = ERROR_ON_FAILURE)
+public class ErrorRule {
+  @When
+  public boolean when() throws Exception {
+    throw new Exception("Sumthin' Broke!");
+  }
+
+  @Then
+  public void then() {}
+}

--- a/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/runner/test/rulebooks/error/condition/SampleRule.java
+++ b/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/runner/test/rulebooks/error/condition/SampleRule.java
@@ -1,4 +1,4 @@
-package com.deliveredtechnologies.rulebook.model.runner.test.rulebooks.error;
+package com.deliveredtechnologies.rulebook.model.runner.test.rulebooks.error.condition;
 
 import com.deliveredtechnologies.rulebook.annotation.Rule;
 import com.deliveredtechnologies.rulebook.annotation.Then;


### PR DESCRIPTION
* Exceptions fixed bubble up in POJO rules "then" when ruleChainAction = ERROR_ON_FAILURE
* Exceptions are now the immediate cause of POJO "when" when ruleChainAction = ERROR_ON_FAILURE